### PR TITLE
Create rake task to create admin users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,9 @@ gem 'devise'
 # Use Rolify to define roles, e.g. "admin", "setter", "athlete", etc.
 gem 'rolify'
 
+# Use Faker when generating sample data and temporary passwords
+gem 'faker'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
@@ -54,8 +57,6 @@ group :development, :test do
 
   # Use Factory Girl to create test data
   gem 'factory_girl_rails'
-  # Use Faker when generating sample data
-  gem 'faker'
 
   # Use RSpec for testing
   gem 'rspec-rails'

--- a/Guardfile
+++ b/Guardfile
@@ -80,6 +80,10 @@ guard :rspec, cmd: "bundle exec rspec" do
   # Factories
   watch(%r(^spec/factories/.+\.rb$)) { rspec.spec_dir }
 
+  # Rake Tasks
+  watch(%r(^lib/tasks/(.+)\.rake$)) { |m| rspec.spec.("tasks/#{m[1]}") }
+  watch(%r(^lib/tasks/(.+)/.+\.rb$)) { |m| "spec/tasks/#{m[1]}" }
+
   # ----------------------------------------------------------------------------
   # App Specific Patterns
   # ----------------------------------------------------------------------------

--- a/lib/tasks/admin/communicator.rb
+++ b/lib/tasks/admin/communicator.rb
@@ -1,0 +1,29 @@
+module Tasks
+  module Admin
+    class Communicator
+      class << self
+        def get_email
+          print 'Please enter the email to be used: '
+          gets.chomp
+        end
+
+        def display_temporary_password(password)
+          puts 'Temporary password is...'
+          puts "  #{password}"
+        end
+
+        def print(string)
+          STDOUT.print string
+        end
+
+        def puts(string)
+          STDOUT.puts string
+        end
+
+        def gets
+          STDIN.gets
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/admin/create.rake
+++ b/lib/tasks/admin/create.rake
@@ -1,0 +1,16 @@
+require_relative 'communicator'
+
+namespace :admin do
+  desc 'Create a new user and assign them the role of admin'
+  task create: :environment do
+    email = Tasks::Admin::Communicator.get_email
+    password = Faker::Internet.password
+    user = User.create!(
+      email: email,
+      password: password,
+      password_confirmation: password
+    )
+    user.add_role :admin
+    Tasks::Admin::Communicator.display_temporary_password(password)
+  end
+end

--- a/spec/tasks/admin/communicator_spec.rb
+++ b/spec/tasks/admin/communicator_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require_relative '../../../lib/tasks/admin/communicator'
+
+RSpec.describe Tasks::Admin::Communicator do
+  it 'delegates print to STDOUT' do
+    expect(STDOUT).to receive(:print)
+    Tasks::Admin::Communicator.print('Foo')
+  end
+
+  it 'delegates `puts` to `STDOUT`' do
+    expect(STDOUT).to receive(:puts)
+    Tasks::Admin::Communicator.puts('Bar')
+  end
+
+  it 'delegates `gets` to `STDIN`' do
+    expect(STDIN).to receive(:gets)
+    Tasks::Admin::Communicator.gets
+  end
+end

--- a/spec/tasks/admin/create_spec.rb
+++ b/spec/tasks/admin/create_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'admin rake tasks' do
+  before :all do
+    Rake.application.rake_require 'tasks/admin/create'
+    Rake::Task.define_task(:environment)
+  end
+
+  describe 'admin:create' do
+    before do
+      allow(Tasks::Admin::Communicator).to receive(
+        :get_email).and_return('amanda@example.com')
+      allow(Tasks::Admin::Communicator).to receive(:display_temporary_password)
+    end
+
+    let :run_rake_task do
+      Rake::Task['admin:create'].reenable
+      Rake.application.invoke_task 'admin:create'
+    end
+
+    it 'creates a user' do
+      expect { run_rake_task }.to change { User.count }.by(1)
+    end
+
+    it 'uses the email specified at the command prompt' do
+      expect(Tasks::Admin::Communicator).to receive(
+        :get_email).and_return('amanda@example.com')
+      run_rake_task
+      user = User.last
+      expect(user.email).to eq 'amanda@example.com'
+    end
+
+    it 'displays the temporary password in the terminal' do
+      expect(Tasks::Admin::Communicator).to receive(
+        :display_temporary_password).with(/.+/)
+      run_rake_task
+    end
+
+    it 'assigns the new user a role of admin' do
+      run_rake_task
+      user = User.last
+      expect(user).to have_role :admin
+    end
+
+    it 'raises an error if the email address is already taken' do
+      create :user, email: 'amanda@example.com'
+      expect { run_rake_task }.to raise_error ActiveRecord::RecordInvalid
+    end
+  end
+end


### PR DESCRIPTION
Adds a new rake task (`admin:create`) which can be used to add new users and assign them the role of admin via the terminal. It will ask for an email to be used when creating the user, and will display the temporary password that was given to the user.
- In the Gemfile, Faker was moved outside of the dev and test groups because we need it for this task, and also for creating sample data in the staging environment (which runs as a Rails production environment).
- Eventually we will probably also want a task to add the role of admin to existing users (or we could allow admins to add the role for existing users through the website).
- If we make more rake tasks that use a communicator class, we'll probably want to create a base class for them that has the delegation methods. BTW, I don't really understand why you need to explicitly specify `STDOUT` and `STDIN` when using `puts`, `gets`, and `print` in rake tasks... I guess rake changes default I/O buffer?
