### PR TITLE
Allow users to change account information

### DIFF
--- a/app/assets/stylesheets/pages/profile/show.scss
+++ b/app/assets/stylesheets/pages/profile/show.scss
@@ -1,0 +1,36 @@
+.profile.show {
+  header {
+    border-bottom: $base-border;
+
+    @include display(flex);
+    @include justify-content(space-between);
+    @include align-items(baseline);
+
+    h2 {
+      margin-bottom: $tiny-spacing;
+    }
+
+    .fa-pencil {
+      font-size: 1.5em;
+    }
+  }
+
+  table {
+    margin: 0 $small-spacing;
+    table-layout: auto;
+
+    * {
+      border: 0;
+    }
+
+    td {
+      padding-left: $base-spacing;
+
+      &:first-child {
+        font-weight: bold;
+        padding-left: 0;
+        text-align: right;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/pages/profile/show.scss
+++ b/app/assets/stylesheets/pages/profile/show.scss
@@ -1,10 +1,10 @@
 .profile.show {
   header {
-    border-bottom: $base-border;
-
     @include display(flex);
     @include justify-content(space-between);
     @include align-items(baseline);
+
+    border-bottom: $base-border;
 
     h2 {
       margin-bottom: $tiny-spacing;

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -1,0 +1,5 @@
+class ProfileController < ApplicationController
+  def show
+    @user = current_user
+  end
+end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,0 +1,20 @@
+%h1 Edit Account Settings
+
+= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+  = devise_error_messages!
+
+  = f.label :email
+  = f.email_field :email, autofocus: true
+
+  = f.label :password, 'New password'
+  %i (leave blank if you don't want to change it)
+  = f.password_field :password, autocomplete: 'off'
+
+  = f.label :password_confirmation, 'Confirm new password'
+  = f.password_field :password_confirmation, autocomplete: 'off'
+
+  = f.label :current_password
+  %i (we need your current password to confirm your changes)
+  = f.password_field :current_password, autocomplete: 'off'
+
+  = f.submit 'Save'

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -17,4 +17,4 @@
         %li.nav-link#sign_out
           = link_to 'Sign Out', destroy_user_session_path, method: :delete
         %li.nav-link
-          = link_to 'Profile', '#'
+          = link_to 'Profile', profile_path

--- a/app/views/profile/show.html.haml
+++ b/app/views/profile/show.html.haml
@@ -1,0 +1,11 @@
+%h1 Your Profile
+
+%section#account_settings
+  %header
+    %h2 Account Settings
+    = link_to edit_user_registration_path do
+      = fa_icon 'pencil', id: 'edit_account_settings'
+  %table
+    %tr
+      %td Email
+      %td= @user.email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,13 +4,13 @@ Rails.application.routes.draw do
   devise_for :users, skip: :registrations
   devise_scope :user do
     resource :registration,
-      only: [:new, :create, :edit, :update],
-      path: 'users',
-      path_names: { new: 'sign_up' },
-      controller: 'devise/registrations',
-      as: :user_registration do
-        get :cancel
-      end
+             only: [:new, :create, :edit, :update],
+             path: 'users',
+             path_names: { new: 'sign_up' },
+             controller: 'devise/registrations',
+             as: :user_registration do
+               get :cancel
+             end
   end
 
   resources :gyms, except: :destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,20 @@
 Rails.application.routes.draw do
   root 'home#show'
 
-  devise_for :users, only: :passwords
+  devise_for :users, skip: :registrations
   devise_scope :user do
-    post 'sign_up', to: 'devise/registrations#create', as: :user_registration
-    post 'sign_in', to: 'devise/sessions#create', as: :user_session
-    delete 'sign_out', to: 'devise/sessions#destroy', as: :destroy_user_session
+    resource :registration,
+      only: [:new, :create, :edit, :update],
+      path: 'users',
+      path_names: { new: 'sign_up' },
+      controller: 'devise/registrations',
+      as: :user_registration do
+        get :cancel
+      end
   end
-  get 'sign_up', to: 'devise/registrations#new', as: :new_user_registration
-  get 'sign_in', to: 'devise/sessions#new', as: :new_user_session
 
   resources :gyms, except: :destroy
   resources :sections, only: [:new, :show]
   resources :climbs, only: [:new, :create]
+  resource :profile, only: [:show], controller: :profile
 end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ProfileController, type: :controller do
+  it { should route(:get, '/profile').to(action: :show) }
+end

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -12,8 +12,7 @@ RSpec.feature 'Homepage', type: :feature, js: true do
     visit root_path
     expect(page).to_not have_selector '#sign_out'
 
-    click_on 'Sign In'
-    login_user
+    create_and_login_user
     expect(page).to be_user_default_page
     expect(page).to have_selector '#sign_out'
 
@@ -28,9 +27,7 @@ RSpec.feature 'Homepage', type: :feature, js: true do
   scenario 'signed-in user clicks on logo' do
     skip
 
-    visit root_path
-    click_on 'Sign In'
-    login_user
+    create_and_login_user
 
     find('.logo').click
     expect(page).to be_user_default_page

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -1,0 +1,24 @@
+require 'feature_helper'
+
+RSpec.feature 'Profile', type: :feature, js: true do
+  scenario 'user edits profile' do
+    user = create_and_login_user
+
+    click_on 'Profile'
+    within '#account_settings' do
+      find('#edit_account_settings').click
+    end
+
+    fill_in 'New password', with: 'new_password'
+    fill_in 'Confirm new password', with: 'new_password'
+    fill_in 'Current password', with: user.password
+    click_on 'Save'
+    user.reload
+
+    expect(page).to show_flash_with 'success'
+
+    sign_out
+    login(user.email, 'new_password')
+    expect(page).to show_flash_with 'Signed in successfully.'
+  end
+end

--- a/spec/features/support/helpers/devise_helper.rb
+++ b/spec/features/support/helpers/devise_helper.rb
@@ -1,16 +1,26 @@
 module DeviseFeatureHelper
   def sign_up_user
     new_user = FactoryGirl.build :user
+    visit root_path
+    click_on 'Sign Up'
     fill_in 'Email', with: new_user.email
     fill_in 'Password', with: new_user.password
     fill_in 'Password confirmation', with: new_user.password
     find('input[type="submit"]').click
+    new_user
   end
 
-  def login_user
+  def create_and_login_user
     user = FactoryGirl.create :user
-    fill_in 'Email', with: user.email
-    fill_in 'Password', with: user.password
+    login(user.email, user.password)
+    user
+  end
+
+  def login(email, password)
+    visit root_path
+    click_on 'Sign In'
+    fill_in 'Email', with: email
+    fill_in 'Password', with: password
     find('input[type="submit"]').click
   end
 


### PR DESCRIPTION
- Rewrote route definitions for Devise to make it easier to work with. The only route we really want to skip is the one for destroying user registrations (at least for now...).
- Refactored the `DeviseFeatureHelper` a little.
- Added a `Profile` controller and view to distinguish between updating general user information, and updating account information (which is controlled by Devise).
- Made a custom view for editing user registration because we aren't initially implementing account deletion (and I wanted to change the header).
