### PR TITLE
Tailor views to current role

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -1,5 +1,6 @@
 class SectionsController < ApplicationController
   def new
+    authorize Section
     @gym_form = GymForm.new
   end
 

--- a/app/models/visitor.rb
+++ b/app/models/visitor.rb
@@ -2,4 +2,8 @@ class Visitor
   def is_admin?
     false
   end
+
+  def current_role
+    ''
+  end
 end

--- a/app/policies/gym_policy.rb
+++ b/app/policies/gym_policy.rb
@@ -1,9 +1,9 @@
 class GymPolicy < ApplicationPolicy
   def create?
-    user.is_admin?
+    user.current_role == 'admin'
   end
 
   def update?
-    user.is_admin?
+    user.current_role == 'admin'
   end
 end

--- a/app/policies/section_policy.rb
+++ b/app/policies/section_policy.rb
@@ -1,0 +1,2 @@
+class SectionPolicy < GymPolicy
+end

--- a/app/views/sections/_show.html.haml
+++ b/app/views/sections/_show.html.haml
@@ -5,4 +5,5 @@
     - section.climbs.each do |climb|
       = link_to climb.grade || '?', '#', class: Climb.color_name_for(climb.color)
 
-  = link_to 'Add Climb', new_climb_path, remote: true, class: 'new-climb-link'
+  - if policy(Section).new?
+    = link_to 'Add Climb', new_climb_path, remote: true, class: 'new-climb-link'

--- a/spec/controllers/sections_controller_spec.rb
+++ b/spec/controllers/sections_controller_spec.rb
@@ -3,4 +3,10 @@ require 'rails_helper'
 RSpec.describe SectionsController, type: :controller do
   it { should route(:get, '/sections/new').to(action: :new) }
   it { should route(:get, '/sections/1').to(action: :show, id: 1) }
+
+  it 'should check authorization for #new' do
+    pretend_not_authorized :new?
+    xhr :get, :new
+    expect_standard_not_authorized_response
+  end
 end

--- a/spec/features/climbs_spec.rb
+++ b/spec/features/climbs_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'Climbs', type: :feature, js: true do
       :with_name,
       section_names: ['Section 1', 'Section 2', 'Section 3']
     )
+    create_and_login_user(:admin)
 
     visit gyms_path
     click_on gym.name

--- a/spec/policies/gym_policy_spec.rb
+++ b/spec/policies/gym_policy_spec.rb
@@ -25,4 +25,13 @@ RSpec.describe GymPolicy do
     it { should permit_new_and_create_actions }
     it { should permit_edit_and_update_actions }
   end
+
+  context "for an admin who's current role isn't admin" do
+    let(:user) do
+      user = create :athlete
+      user.add_role :admin
+      user
+    end
+    it_behaves_like 'a gym policy for a non-admin user'
+  end
 end

--- a/spec/policies/section_policy_spec.rb
+++ b/spec/policies/section_policy_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe SectionPolicy do
+  it 'should defer all decisions to GymPolicy' do
+    expect(SectionPolicy.superclass).to eq GymPolicy
+    expect(SectionPolicy.instance_methods(false)).to be_empty
+  end
+end

--- a/spec/support/helpers/authorization_helper.rb
+++ b/spec/support/helpers/authorization_helper.rb
@@ -6,7 +6,9 @@ module AuthorizationHelper
 
   def pretend_not_authorized(authorization_method_name)
     policy = double(authorization_method_name => false)
-    allow(GymPolicy).to receive(:new).and_return(policy)
+    policy_class_name =
+      described_class.to_s.match(/(.+)Controller$/)[1].singularize + 'Policy'
+    allow(policy_class_name.constantize).to receive(:new).and_return(policy)
   end
 end
 

--- a/spec/views/gyms/index.html.haml_spec.rb
+++ b/spec/views/gyms/index.html.haml_spec.rb
@@ -1,11 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe 'gyms/index.html.haml', type: :view do
-  context 'for a non-admin user' do
+  context "when the user's current role isn't admin" do
     it "doesn't show the link to create a new gym" do
-      allow(view).to receive(:current_user).and_return(Visitor.new)
+      user = create :athlete
+      user.add_role :admin
+      allow(view).to receive(:current_user).and_return(user)
       assign(:gyms, create_list(:gym, 2))
+
       render
+
       expect(rendered).to_not have_selector '#new_gym'
     end
   end

--- a/spec/views/sections/_show.html.haml_spec.rb
+++ b/spec/views/sections/_show.html.haml_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'sections/_show.html.haml', type: :view do
+  context 'for a non-admin user' do
+    it "doesn't show a link to add a new climb" do
+      allow(view).to receive(:current_user).and_return(create(:user))
+      def view.policy(model)
+        Pundit.policy(current_user, model)
+      end
+
+      render 'sections/show.html.haml',
+        section: create(:gym, :with_named_section).sections.first
+
+      expect(rendered).to_not have_selector '.new-climb-link'
+    end
+  end
+end


### PR DESCRIPTION
- Create a `SectionPolicy` and use it in the section controller and show view.
- Small fix to authorization spec helper
- Modify policies to look only at current role
