### PR TITLE
Review feature specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,9 @@ group :test do
 
   # Use SimpleCov for test coverage reporting on local machines
   gem 'simplecov', require: false
+
+  # Use launchy to automatically open page snapshots taken during feaure specs
+  gem 'launchy'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,8 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (3.0.6)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
@@ -320,6 +322,7 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.0)
   jquery-rails
+  launchy
   neat
   pg (~> 0.15)
   pry

--- a/spec/features/climbs_spec.rb
+++ b/spec/features/climbs_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Climbs', type: :feature, js: true do
       :with_name,
       section_names: ['Section 1']
     )
-    sign_in create(:admin)
+    stubbed_sign_in create(:admin)
 
     visit gyms_path
     click_on gym.name

--- a/spec/features/climbs_spec.rb
+++ b/spec/features/climbs_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Climbs', type: :feature, js: true do
       :with_name,
       section_names: ['Section 1']
     )
-    create_and_login_user(:admin)
+    sign_in create(:admin)
 
     visit gyms_path
     click_on gym.name

--- a/spec/features/climbs_spec.rb
+++ b/spec/features/climbs_spec.rb
@@ -5,17 +5,17 @@ RSpec.feature 'Climbs', type: :feature, js: true do
     gym = create(
       :gym,
       :with_name,
-      section_names: ['Section 1', 'Section 2', 'Section 3']
+      section_names: ['Section 1']
     )
     create_and_login_user(:admin)
 
     visit gyms_path
     click_on gym.name
-    click_on 'Section 2'
+    click_on 'Section 1'
     click_on 'Add Climb'
 
     climb_form = PageObjects::Climbs::Form.on_page!
-    expect(climb_form).to be_for_section 'Section 2'
+    expect(climb_form).to be_for_section 'Section 1'
 
     climb_form.choose_route
     climb_form.grade = '5.11b'

--- a/spec/features/gyms_spec.rb
+++ b/spec/features/gyms_spec.rb
@@ -23,8 +23,8 @@ RSpec.feature "Gyms", type: :feature, js: true do
     gym_form.next_section_name = 'The Slab'
     gym_form.submit
 
-    index_page = PageObjects::Gyms::Index.on_page!
     expect(page).to show_flash_with 'success'
+    index_page = PageObjects::Gyms::Index.on_page!
     expect(index_page).to have_gym 'Wild Walls'
 
     ww = Gym.find_by_name('Wild Walls')

--- a/spec/features/gyms_spec.rb
+++ b/spec/features/gyms_spec.rb
@@ -2,7 +2,7 @@ require "feature_helper"
 
 RSpec.feature "Gyms", type: :feature, js: true do
   scenario "(admin) creates a gym" do
-    sign_in create(:admin)
+    stubbed_sign_in create(:admin)
     visit new_gym_path
     gym_form = PageObjects::Gyms::Form.on_page!
 
@@ -43,7 +43,7 @@ RSpec.feature "Gyms", type: :feature, js: true do
       :with_name,
       section_names: section_names
     )
-    sign_in create(:admin)
+    stubbed_sign_in create(:admin)
 
     visit gyms_path
     click_on gym.name

--- a/spec/features/gyms_spec.rb
+++ b/spec/features/gyms_spec.rb
@@ -2,7 +2,7 @@ require "feature_helper"
 
 RSpec.feature "Gyms", type: :feature, js: true do
   scenario "(admin) creates a gym" do
-    create_and_login_user(:admin)
+    sign_in create(:admin)
     visit new_gym_path
     gym_form = PageObjects::Gyms::Form.on_page!
 
@@ -43,7 +43,7 @@ RSpec.feature "Gyms", type: :feature, js: true do
       :with_name,
       section_names: section_names
     )
-    create_and_login_user(:admin)
+    sign_in create(:admin)
 
     visit gyms_path
     click_on gym.name

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -4,8 +4,7 @@ RSpec.feature 'Homepage', type: :feature do
   scenario 'guest visits homepage and creates an account' do
     visit root_path
 
-    user = sign_up_user
-    expect(page).to be_user_default_page
+    user = sign_up
     expect(user.current_role).to eq 'athlete'
   end
 
@@ -13,7 +12,7 @@ RSpec.feature 'Homepage', type: :feature do
     visit root_path
     expect(page).to_not have_selector '#sign_out'
 
-    create_and_login_user
+    sign_in create(:user)
     expect(page).to be_user_default_page
     expect(page).to have_selector '#sign_out'
 

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -1,6 +1,6 @@
 require 'feature_helper'
 
-RSpec.feature 'Homepage', type: :feature, js: true do
+RSpec.feature 'Homepage', type: :feature do
   scenario 'guest visits homepage and creates an account' do
     visit root_path
 

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Homepage', type: :feature do
     expect(page).to_not have_selector '.sign-up'
     expect(page).to_not have_selector '.sign-in'
 
-    sign_out
+    stubbed_sign_out
     expect(page).to be_homepage
   end
 end

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -2,7 +2,8 @@ require 'feature_helper'
 
 RSpec.feature 'Profile', type: :feature, js: true do
   scenario 'user edits profile' do
-    user = create_and_login_user
+    user = create :user
+    sign_in user
 
     click_on 'Profile'
     within '#account_settings' do
@@ -18,7 +19,7 @@ RSpec.feature 'Profile', type: :feature, js: true do
     expect(page).to show_flash_with 'success'
 
     sign_out
-    login(user.email, 'new_password')
+    sign_in(user, password: 'new_password')
     expect(page).to show_flash_with 'Signed in successfully.'
   end
 end

--- a/spec/features/profile_spec.rb
+++ b/spec/features/profile_spec.rb
@@ -3,7 +3,8 @@ require 'feature_helper'
 RSpec.feature 'Profile', type: :feature, js: true do
   scenario 'user edits profile' do
     user = create :user
-    sign_in user
+    stubbed_sign_in user
+    visit root_path
 
     click_on 'Profile'
     within '#account_settings' do
@@ -18,7 +19,7 @@ RSpec.feature 'Profile', type: :feature, js: true do
 
     expect(page).to show_flash_with 'success'
 
-    sign_out
+    stubbed_sign_out
     sign_in(user, password: 'new_password')
     expect(page).to show_flash_with 'Signed in successfully.'
   end

--- a/spec/features/support/helpers/devise_helper.rb
+++ b/spec/features/support/helpers/devise_helper.rb
@@ -1,4 +1,15 @@
 module DeviseFeatureHelper
+  # Use the stubbed out methods unless you're testing something related to
+  # sessions and registration. It saves about half a second per feature spec.
+  # The `login_as` and `logout` methods are from Warden::Test::Helpers.
+  def stubbed_sign_in(user)
+    login_as(user, scope: :user)
+  end
+
+  def stubbed_sign_out
+    logout(:user)
+  end
+
   def sign_up
     attributes = FactoryGirl.attributes_for :user
     visit root_path
@@ -28,5 +39,9 @@ module DeviseFeatureHelper
 end
 
 RSpec.configure do |config|
+  config.include Warden::Test::Helpers, type: :feature
+  Warden.test_mode!
+  config.after(:each, type: :feature) { Warden.test_reset! }
+
   config.include DeviseFeatureHelper, type: :feature
 end

--- a/spec/features/support/helpers/devise_helper.rb
+++ b/spec/features/support/helpers/devise_helper.rb
@@ -1,29 +1,23 @@
 module DeviseFeatureHelper
-  def sign_up_user
-    new_user = FactoryGirl.build :user
+  def sign_up
+    attributes = FactoryGirl.attributes_for :user
     visit root_path
     click_on 'Sign Up'
     within '.sign-up' do
-      fill_in 'Email', with: new_user.email
-      fill_in 'Password', with: new_user.password
-      fill_in 'Password confirmation', with: new_user.password
+      fill_in 'Email', with: attributes[:email]
+      fill_in 'Password', with: attributes[:password]
+      fill_in 'Password confirmation', with: attributes[:password]
       find('input[type="submit"]').click
     end
-    User.find_by_email new_user.email
+    User.find_by_email attributes[:email]
   end
 
-  def create_and_login_user(factory_name = :user)
-    user = FactoryGirl.create factory_name
-    login(user.email, user.password)
-    user
-  end
-
-  def login(email, password)
+  def sign_in(user, options = {})
     visit root_path
     click_on 'Sign In'
     within '.sign-in' do
-      fill_in 'Email', with: email
-      fill_in 'Password', with: password
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: (options[:password] || user.password)
       find('input[type="submit"]').click
     end
   end

--- a/spec/features/users/current_roles_spec.rb
+++ b/spec/features/users/current_roles_spec.rb
@@ -4,7 +4,8 @@ RSpec.feature 'User Roles', type: :feature, js: true do
   scenario 'user switches current role' do
     user = create :admin
     user.add_role :athlete
-    sign_in user
+    stubbed_sign_in user
+    visit root_path
     find_link('Switch Roles').hover
     expect(page).to have_select('user[current_role]', selected: 'admin')
     select 'athlete'

--- a/spec/features/users/current_roles_spec.rb
+++ b/spec/features/users/current_roles_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'User Roles', type: :feature, js: true do
   scenario 'user switches current role' do
     user = create :admin
     user.add_role :athlete
-    login(user.email, user.password)
+    sign_in user
     find_link('Switch Roles').hover
     expect(page).to have_select('user[current_role]', selected: 'admin')
     select 'athlete'


### PR DESCRIPTION
- Don't use `js: true` unless it is actually needed (e.g. I originally thought I needed when running through sign in and sign up, but I realized I could avoid the visibility issue via Capybara options).
- Renamed and re-implemented the methods to be simpler
- Created stubbed sign in and sign out methods to speed up feature specs a little, but left the old versions in there because the non-stubbed ones should be used when you're testing sign in and sign out related stuff. Got the idea from http://www.schneems.com/post/15948562424/speed-up-capybara-tests-with-devise/.
