### PR TITLE
Hack to make flex items shrink

### DIFF
--- a/app/assets/stylesheets/pages/gyms/_show.scss
+++ b/app/assets/stylesheets/pages/gyms/_show.scss
@@ -23,7 +23,7 @@
 
   #current_section {
     @include flex-grow(1);
-    
+
     margin-top: $base-spacing;
     margin-bottom: $base-spacing;
 
@@ -60,6 +60,7 @@
 
     > * {
       margin-top: $base-spacing;
+      min-width: 0;
     }
   }
 


### PR DESCRIPTION
As describe here: [No Overflow for My Flexbox](https://teamtreehouse.com/community/no-overflow-for-my-flexbox), you can just add `min-width: 0` to the items that aren't shrinking... not sure why this works. Also, it only seems to be necessary when there are images in the flexbox (I think...).

Closes #31 
