### PR TITLE
Use `button_to` when changes are made to application records

### DIFF
--- a/app/assets/stylesheets/pages/gyms/_show.scss
+++ b/app/assets/stylesheets/pages/gyms/_show.scss
@@ -5,18 +5,21 @@
 
     @include display(flex);
     @include flex-wrap(wrap);
-    a {
+
+    .button_to input[type="submit"] {
       @include compact-bitter-button;
       @include no-color-button;
+
       border-radius: 0;
       margin: 1px;
       text-align: center;
       width: 4em;
-    }
-    @each $color-name, $color-value in $climb-colors {
-      a.#{$color-name} {
-        background: none;
-        @include button-color($color-value);
+
+      @each $color-name, $color-value in $climb-colors {
+        &.#{$color-name} {
+          background: none;
+          @include button-color($color-value);
+        }
       }
     }
   }
@@ -81,12 +84,12 @@
     }
   }
 
-  ul {
+  .sections {
     background-color: $emphasis-background-color;
     padding: $small-spacing;
     padding-bottom: 0;
 
-    li {
+    > * {
       a {
         @include bitter-button(white, $border: 0);
         border-radius: 0;

--- a/app/views/sections/_show.html.haml
+++ b/app/views/sections/_show.html.haml
@@ -3,12 +3,12 @@
 
   #climbs
     - section.climbs.active.includes(:grade).each do |climb|
-      = link_to climb.grade.name,
-                athletes_climb_logs_path,
-                class: climb.color_name,
-                remote: true,
-                method: :post,
-                data: { params: { climb_log: { climb_id: climb.id } } }
+      = button_to climb.grade.name,
+                  athletes_climb_logs_path,
+                  class: climb.color_name,
+                  remote: true,
+                  method: :post,
+                  params: { 'climb_log[climb_id]': climb.id }
 
   - if policy(Climb).new?
     = link_to 'Add Climb',

--- a/spec/features/athletes/climb_logs_spec.rb
+++ b/spec/features/athletes/climb_logs_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Athlete Climb Logs', type: :feature, js: true do
       visit gym_path(gym)
       click_on gym.sections.first.name
       expect do
-        first('#climbs a').click
+        first('#climbs .button_to').click
         wait_for_ajax
       end.to change { user.athlete_story.climb_logs.count }.by(1)
       expect(page).to show_flash_with 'successfully logged'

--- a/spec/features/climbs_spec.rb
+++ b/spec/features/climbs_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature 'Climbs', type: :feature, js: true do
 
     expect(page).to show_flash_with 'success'
     page_should_replace_form_with_section_overview
-    page_should_have_climb '5.11b', 'pink'
+    expect(page).to have_climb '5.11b', 'pink'
   end
 
   def page_should_replace_form_with_section_overview
@@ -33,7 +33,7 @@ RSpec.feature 'Climbs', type: :feature, js: true do
     expect(page).to have_selector('#current_section', count: 1)
   end
 
-  def page_should_have_climb(grade, color)
-    expect(page).to have_selector "a.#{color.downcase}", text: grade
+  def have_climb(grade, color)
+    have_selector ".button_to .#{color.downcase}[value='#{grade}']"
   end
 end


### PR DESCRIPTION
Search bots won't click on these buttons because they're within a form. Not super important for this page because it is only visible when a user is logged in, but still a good practice.

Closes #38 
