### PR TITLE
Use custom validation for role whitelist

### DIFF
--- a/app/forms/employment_form.rb
+++ b/app/forms/employment_form.rb
@@ -6,7 +6,7 @@ class EmploymentForm < BaseForm
 
   validates :email, presence: true
   validates :role_name, presence: true
-  validates :role_name, inclusion: { in: Employment.roles.map(&:to_s) }
+  validate :role_name_must_be_whitelisted
   validates :user, presence: true
 
   def initialize(attribs = {})
@@ -42,6 +42,20 @@ class EmploymentForm < BaseForm
 
   def submit_path
     url_helpers.gym_employments_path(gym)
+  end
+
+  # This allows us to have the `Employment.roles` list change while the
+  # application is running (that is why I didn't use the built in inclusion
+  # matcher). It allows means that it doesn't matter if this file is loaded
+  # before the role story models (during eager loading).
+  def role_name_must_be_whitelisted
+    unless role_name.present? && Employment.roles.include?(role_name.to_sym)
+      role_names_to_sentence = Employment.roles.to_sentence(
+        two_words_connector: ' or ',
+        last_word_connector: ', or '
+      )
+      errors.add(:role_name, "must be one of \"#{}\"")
+    end
   end
 
   private

--- a/app/forms/employment_form.rb
+++ b/app/forms/employment_form.rb
@@ -54,7 +54,7 @@ class EmploymentForm < BaseForm
         two_words_connector: ' or ',
         last_word_connector: ', or '
       )
-      errors.add(:role_name, "must be one of \"#{}\"")
+      errors.add(:role_name, "must be one of \"#{role_names_to_sentence}\"")
     end
   end
 

--- a/config/initializers/employable.rb
+++ b/config/initializers/employable.rb
@@ -1,5 +1,5 @@
-if Rails.application.config.cache_classes == false ||
-   Rails.application.config.eager_load == false
+unless Rails.application.config.cache_classes &&
+       Rails.application.config.eager_load
   ActionDispatch::Reloader.to_prepare do
     Dir["#{Rails.root}/app/models/*_story.rb"].each do |file|
       require_dependency file

--- a/spec/forms/employment_form_spec.rb
+++ b/spec/forms/employment_form_spec.rb
@@ -11,12 +11,20 @@ RSpec.describe EmploymentForm, type: :model do
   it { should validate_presence_of :role_name }
 
   it 'is invalid if the employment record is invalid' do
-    allow(valid_ef.to_model).to receive(:valid?).and_return(false)
+    allow(valid_ef.employment).to receive(:valid?).and_return(false)
     expect(valid_ef).to_not be_valid
   end
 
   it 'is invalid if a user cannot be found with the given email' do
     expect(build(:employment_form, :with_unregistered_email)).to_not be_valid
+  end
+
+  it 'is invalid if the role name is not in `Employment.list`' do
+    expect(build(:employment_form, role_name: 'fake')).to_not be_valid
+  end
+
+  it 'is invalid without a role name' do
+    expect(build(:employment_form, role_name: nil)).to_not be_valid
   end
 
   describe '#initialize' do


### PR DESCRIPTION
This means that the `Employment.roles` list can change while the application is running (e.g. if we eventually add functionality for end users to define roles). More important for right now is that it means it doesn't matter that `app/forms/employment_form.rb` is loaded before the role story models.

Closes #71 
