### PR TITLE
Scope my log link

### DIFF
--- a/app/controllers/athletes/climb_logs_controller.rb
+++ b/app/controllers/athletes/climb_logs_controller.rb
@@ -1,4 +1,6 @@
 class Athletes::ClimbLogsController < ApplicationController
+  before_action :verify_current_user_is_athlete
+
   def create
     if ClimbLogger.new(climb_log_params, current_user).log
       flash[:notice] = 'Climb successfully logged!'
@@ -15,5 +17,12 @@ class Athletes::ClimbLogsController < ApplicationController
 
   def climb_log_params
     params.require(:climb_log).permit(:climb_id)
+  end
+
+  def verify_current_user_is_athlete
+    unless current_user.has_role? :athlete
+      flash[:alert] = 'Sorry, only athletes have a climb log.'
+      redirect_to :back
+    end
   end
 end

--- a/app/models/visitor.rb
+++ b/app/models/visitor.rb
@@ -18,4 +18,12 @@ class Visitor
   def athlete_story
     nil
   end
+
+  def roles
+    []
+  end
+
+  def has_role?(*_args)
+    false
+  end
 end

--- a/app/models/visitor.rb
+++ b/app/models/visitor.rb
@@ -14,4 +14,8 @@ class Visitor
   def employed_at?(*_args)
     false
   end
+
+  def athlete_story
+    nil
+  end
 end

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -10,7 +10,7 @@
         = link_to 'Gyms', gyms_path
       %li.nav-link
         = link_to 'Ipsum', '#'
-      - if user_signed_in? && current_user.has_role?(:athlete)
+      - if user_signed_in? && (current_user.current_role == 'athlete')
         %li.nav-link
           = link_to 'My Log', athletes_climb_logs_path
     - if user_signed_in?

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -10,8 +10,9 @@
         = link_to 'Gyms', gyms_path
       %li.nav-link
         = link_to 'Ipsum', '#'
-      %li.nav-link
-        = link_to 'My Log', athletes_climb_logs_path
+      - if user_signed_in? && current_user.has_role?(:athlete)
+        %li.nav-link
+          = link_to 'My Log', athletes_climb_logs_path
     - if user_signed_in?
       %ul#navbar_tools
         %li.nav-link#sign_out

--- a/spec/controllers/athletes/climb_logs_controller_spec.rb
+++ b/spec/controllers/athletes/climb_logs_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Athletes::ClimbLogsController, type: :controller do
 
   describe '#create' do
     it 'uses strong parameters' do
-      login_user :athlete
+      create_and_login_user :athlete
       params = { climb_log: { climb_id: create(:climb).id }, format: 'js' }
 
       expect(subject).to permit(:climb_id).for(
@@ -14,9 +14,10 @@ RSpec.describe Athletes::ClimbLogsController, type: :controller do
     end
 
     it 'sets a flash alert message when no climb is specified' do
-      login_user :athlete
+      athlete = create :athlete
+      login athlete
       params = {
-        climb_log: { athlete_story_id: User.first.athlete_story.id },
+        climb_log: { athlete_story_id: athlete.athlete_story.id },
         format: 'js'
       }
 
@@ -27,7 +28,7 @@ RSpec.describe Athletes::ClimbLogsController, type: :controller do
 
     it "sets a flash alert message and redirects back when the user isn't an "\
        'athlete' do
-      login_user :setter
+      create_and_login_user :setter
       params = { climb_log: { climb_id: create(:climb).id }, format: 'js' }
       request.env["HTTP_REFERER"] = 'starting_page'
 

--- a/spec/controllers/athletes/climb_logs_controller_spec.rb
+++ b/spec/controllers/athletes/climb_logs_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Athletes::ClimbLogsController, type: :controller do
        'athlete' do
       create_and_login_user :setter
       params = { climb_log: { climb_id: create(:climb).id }, format: 'js' }
-      request.env["HTTP_REFERER"] = 'starting_page'
+      request.env['HTTP_REFERER'] = 'starting_page'
 
       xhr :post, :create, params
 

--- a/spec/controllers/athletes/climb_logs_controller_spec.rb
+++ b/spec/controllers/athletes/climb_logs_controller_spec.rb
@@ -4,35 +4,37 @@ RSpec.describe Athletes::ClimbLogsController, type: :controller do
   it { should route(:post, 'athletes/climb_logs').to(action: :create) }
   it { should route(:get, 'athletes/climb_logs').to(action: :index) }
 
-  before :each do
-    login_user :athlete
-  end
-
   describe '#create' do
     it 'uses strong parameters' do
-      climb = create :climb
-      params = {
-        climb_log: {
-          athlete_story_id: User.first.athlete_story.id,
-          climb_id: climb.id
-        },
-        format: 'js'
-      }
+      login_user :athlete
+      params = { climb_log: { climb_id: create(:climb).id }, format: 'js' }
 
       expect(subject).to permit(:climb_id).for(
         :create, params: params).on(:climb_log)
     end
 
-    context 'when no climb is specified' do
-      it 'sets a flash alert message' do
-        params = {
-          climb_log: { athlete_story_id: User.first.athlete_story.id },
-          format: 'js'
-        }
-        xhr :post, :create, params
+    it 'sets a flash alert message when no climb is specified' do
+      login_user :athlete
+      params = {
+        climb_log: { athlete_story_id: User.first.athlete_story.id },
+        format: 'js'
+      }
 
-        expect(flash[:alert]).to be_present
-      end
+      xhr :post, :create, params
+
+      expect(flash[:alert]).to be_present
+    end
+
+    it "sets a flash alert message and redirects back when the user isn't an "\
+       'athlete' do
+      login_user :setter
+      params = { climb_log: { climb_id: create(:climb).id }, format: 'js' }
+      request.env["HTTP_REFERER"] = 'starting_page'
+
+      xhr :post, :create, params
+
+      expect(response).to redirect_to 'starting_page'
+      expect(flash[:alert]).to eq 'Sorry, only athletes have a climb log.'
     end
   end
 end

--- a/spec/controllers/climbs_controller_spec.rb
+++ b/spec/controllers/climbs_controller_spec.rb
@@ -25,9 +25,8 @@ RSpec.describe ClimbsController, type: :controller do
   end
 
   describe '#create' do
-    before(:each) { login_user :setter }
-
     it 'uses strong parameters' do
+      create_and_login_user :setter
       params = {
         section_id: 1,
         climb: attributes_for(:climb, :with_grade, :with_color),

--- a/spec/controllers/gyms_controller_spec.rb
+++ b/spec/controllers/gyms_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe GymsController, type: :controller do
 
   describe '#create' do
     before :each do
-      login_user :admin
+      create_and_login_user :admin
     end
 
     it 'uses strong parameters' do
@@ -68,7 +68,7 @@ RSpec.describe GymsController, type: :controller do
 
   describe '#update' do
     before :each do
-      login_user :admin
+      create_and_login_user :admin
     end
 
     it 'uses strong parameters' do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -58,4 +58,8 @@ FactoryGirl.define do
       end
     end
   end
+
+  factory :visitor do
+    skip_create
+  end
 end

--- a/spec/support/helpers/devise_helper.rb
+++ b/spec/support/helpers/devise_helper.rb
@@ -3,9 +3,13 @@ module DeviseHelper
     @request.env['devise.mapping'] = Devise.mappings[:user]
   end
 
-  def login_user(factory_name = :user)
-    @request.env['devise.mapping'] = Devise.mappings[:user]
+  def create_and_login_user(factory_name = :user)
     user = create(factory_name)
+    login user
+  end
+
+  def login(user)
+    @request.env['devise.mapping'] = Devise.mappings[:user]
     sign_in user
   end
 end

--- a/spec/views/layouts/_navbar.html.haml_spec.rb
+++ b/spec/views/layouts/_navbar.html.haml_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe 'layouts/_navbar.html.haml', type: :view do
+  it "doesn't show the 'My Log' link when the current user isn't an athlete" do
+    allow(controller).to receive(:current_user).and_return(create(:visitor))
+
+    render
+
+    expect(rendered).to_not have_link 'My Log'
+  end
+end

--- a/spec/views/layouts/_navbar.html.haml_spec.rb
+++ b/spec/views/layouts/_navbar.html.haml_spec.rb
@@ -1,8 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe 'layouts/_navbar.html.haml', type: :view do
-  it "doesn't show the 'My Log' link when the current user isn't an athlete" do
-    allow(controller).to receive(:current_user).and_return(create(:visitor))
+  it "doesn't show the 'My Log' link when the current user's current role "\
+     "isn't an athlete" do
+    user = create :setter
+    user.add_role :athlete
+    allow(controller).to receive(:current_user).and_return(user)
 
     render
 


### PR DESCRIPTION
- Hide the "My Log" link unless the user's current role is athlete.
- Give prettier results if somehow a non-athlete tries to view their "climb log".

Closes #45 
