### PR TITLE
Don't create a section by default

### DIFF
--- a/app/controllers/gyms_controller.rb
+++ b/app/controllers/gyms_controller.rb
@@ -3,10 +3,11 @@ class GymsController < ApplicationController
 
   def new
     @gym_form ||= GymForm.new
+    @gym_form.add_section
   end
 
   def create
-    @gym_form = GymForm.new
+    @gym_form ||= GymForm.new
     @gym_form.attributes = gym_form_params
     if @gym_form.save
       redirect_to gyms_path, notice: 'New gym successfully created!'

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -2,6 +2,7 @@ class SectionsController < ApplicationController
   def new
     authorize Section
     @gym_form = GymForm.new
+    @gym_form.add_section
   end
 
   def show

--- a/app/forms/gym_form.rb
+++ b/app/forms/gym_form.rb
@@ -6,9 +6,6 @@ class GymForm < BaseForm
   def initialize(gym = nil)
     @gym = gym || Gym.new
     @sections = @gym.sections.to_a
-    if @sections.empty?
-      @sections << Section.new
-    end
   end
 
   def attributes=(attribs)
@@ -45,6 +42,10 @@ class GymForm < BaseForm
 
   def to_partial_path
     'gyms/form'
+  end
+
+  def add_section
+    sections << Section.new
   end
 
   private

--- a/spec/forms/gym_form_spec.rb
+++ b/spec/forms/gym_form_spec.rb
@@ -2,15 +2,6 @@ require 'rails_helper'
 
 RSpec.describe GymForm do
   describe '#initialize' do
-    context 'when given no arguments' do
-      it 'builds a new gym with one section' do
-        gym_form = GymForm.new
-
-        expect(gym_form.sections.size).to eq 1
-        expect(gym_form.sections.first).to be_a_new_record
-      end
-    end
-
     context 'when given a gym record' do
       it "makes the record's attributes available through the form object" do
         gym = build :gym, :with_name, :with_named_section
@@ -103,6 +94,16 @@ RSpec.describe GymForm do
       gym_form.save
 
       expect(gym.sections).to be_empty
+    end
+  end
+
+  describe '#add_section' do
+    it 'adds a new section' do
+      gym = create :gym
+      gym_form = GymForm.new(gym)
+
+      expect { gym_form.add_section }.to \
+        change { gym_form.sections.count }.by(1)
     end
   end
 end


### PR DESCRIPTION
Instead have those building section forms add a section when they want.

Always building a section when the gym's sections collection was blank was doing too much. E.g. the gym might not yet have any saved sections, but the end user could have already built up some (unsaved) sections (see issue #49).

Closes #49
