### PR TITLE
Restrict climb log buttons

### DIFF
--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -47,7 +47,7 @@ select[multiple] {
     outline: none;
   }
 
-  &:disabled {
+  &:disabled.disabled {
     background-color: shade($input-background-color, 5%);
     cursor: not-allowed;
 
@@ -120,7 +120,7 @@ select {
     outline: none;
   }
 
-  &:disabled {
+  &:disabled.disabled {
     background-color: shade($input-background-color, 5%);
     cursor: not-allowed;
 

--- a/app/assets/stylesheets/base/helpers/_buttons.scss
+++ b/app/assets/stylesheets/base/helpers/_buttons.scss
@@ -43,6 +43,10 @@
     cursor: not-allowed;
   }
 
+  &:disabled.no-interraction {
+    cursor: default;
+  }
+
   @include button-color($color, $text-color, $border);
 }
 
@@ -74,6 +78,15 @@
       background-color: $color;
     }
   }
+
+  &:disabled.no-interraction {
+    &:hover,
+    &:focus {
+      background: none;
+      background-color: $color;
+      cursor: default;
+    }
+  }
 }
 
 @mixin no-color-button {
@@ -90,6 +103,14 @@
   &:disabled.disabled {
     &:hover {
       @include no-color-background;
+    }
+  }
+
+  &:disabled.no-interraction {
+    &:hover,
+    &:focus {
+      @include no-color-background;
+      cursor: default;
     }
   }
 }

--- a/app/assets/stylesheets/base/helpers/_buttons.scss
+++ b/app/assets/stylesheets/base/helpers/_buttons.scss
@@ -39,7 +39,7 @@
   vertical-align: middle;
   white-space: nowrap;
 
-  &:disabled {
+  &:disabled.disabled {
     cursor: not-allowed;
   }
 
@@ -68,7 +68,7 @@
     color: $text-color;
   }
 
-  &:disabled {
+  &:disabled.disabled {
     opacity: 0.5;
     &:hover {
       background-color: $color;
@@ -87,7 +87,7 @@
     color: $base-font-color;
   }
 
-  &:disabled {
+  &:disabled.disabled {
     &:hover {
       @include no-color-background;
     }

--- a/app/assets/stylesheets/pages/gyms/_show.scss
+++ b/app/assets/stylesheets/pages/gyms/_show.scss
@@ -7,7 +7,7 @@
     @include display(flex);
     @include flex-wrap(wrap);
 
-    .button_to input[type="submit"] {
+    .button_to .climb {
       @include compact-bitter-button;
       @include no-color-button;
 

--- a/app/helpers/climb_helper.rb
+++ b/app/helpers/climb_helper.rb
@@ -2,4 +2,18 @@ module ClimbHelper
   def data_for_color_options
     Climb.colors.map { |hex, _id| [Climb.color_name_for(hex), hex] }
   end
+
+  def button_to_log_climb(climb, options = {})
+    merged_options = {
+      class: [climb.color_name, 'climb'],
+      remote: true,
+      method: :post,
+      params: { 'climb_log[climb_id]': climb.id }
+    }
+    merged_options[:class] += Array(options.delete(:class))
+    merged_options = merged_options.merge(options)
+    button_to climb.grade.name,
+              athletes_climb_logs_path,
+              merged_options
+  end
 end

--- a/app/views/sections/_show.html.haml
+++ b/app/views/sections/_show.html.haml
@@ -3,12 +3,10 @@
 
   #climbs
     - section.climbs.active.includes(:grade).each do |climb|
-      = button_to climb.grade.name,
-                  athletes_climb_logs_path,
-                  class: climb.color_name,
-                  remote: true,
-                  method: :post,
-                  params: { 'climb_log[climb_id]': climb.id }
+      - if current_user.current_role == 'athlete'
+        = button_to_log_climb(climb)
+      - else
+        = button_to_log_climb(climb, disabled: true, class: 'no-interraction')
 
   - if policy(Climb.new(section: section)).create?
     = link_to 'Add Climb',

--- a/spec/features/athletes/climb_logs_spec.rb
+++ b/spec/features/athletes/climb_logs_spec.rb
@@ -29,4 +29,16 @@ RSpec.feature 'Athlete Climb Logs', type: :feature, js: true do
     expect(logs_index_page.current_gym_name).to_not eq original_gym_name
     expect(logs_index_page).to be_showing_valid_gym_section_and_logs_for user
   end
+
+  scenario "when the user's current role isn't athlete, the buttons don't act"\
+           ' clickable' do
+    setter = create :setter
+    gym = create :tiny_boulder_gym
+    stubbed_sign_in setter
+    visit gym_path(gym)
+    click_on gym.sections.first.name
+    wait_for_ajax
+
+    expect(page).to have_selector '.climb:disabled.no-interraction'
+  end
 end


### PR DESCRIPTION
They shouldn't look or act like buttons unless the user is currently logged in as an athlete.
